### PR TITLE
Create `package.json` to prepare for npm release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "thelounge-theme-light",
+  "version": "1.0.0",
+  "description": "A simple theme for The Lounge with custom highlights",
+  "main": "package.json",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/bews/lounge-light.git"
+  },
+  "keywords": [
+    "thelounge",
+    "thelounge-theme"
+  ],
+  "author": "bews",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/bews/lounge-light/issues"
+  },
+  "homepage": "https://github.com/bews/lounge-light#readme",
+  "thelounge": {
+    "css": "light.css",
+    "name": "Light",
+    "type": "theme"
+  }
+}


### PR DESCRIPTION
This file was created by following steps listed at thelounge.github.io/docs/plugins/themes.html.

After publishing it on npm, it will be available with all other themes https://www.npmjs.com/search?q=keywords%3Athelounge-theme

It can then be installed on The Lounge (as of [v2.5.0](https://github.com/thelounge/lounge/releases/tag/v2.5.0)) using the `lounge install` (prior to v2.7.0) or `thelounge install` (v2.7.0 and up) command.